### PR TITLE
Remove break statements as they may lead to fields being reset

### DIFF
--- a/wfdm-file-index-service/src/main/java/ca/bc/gov/nrs/wfdm/wfdm_file_index_service/GetFileFromWFDMAPI.java
+++ b/wfdm-file-index-service/src/main/java/ca/bc/gov/nrs/wfdm/wfdm_file_index_service/GetFileFromWFDMAPI.java
@@ -94,11 +94,9 @@ public class GetFileFromWFDMAPI {
       if (metadataName.equalsIgnoreCase("WFDMIndexVersion-" + versionNumber)
           || (metadataName.equalsIgnoreCase("wfdm-indexed-v" + versionNumber))) {
         metaArray.remove(i);
-        break;
       }
       if (metadataName.equalsIgnoreCase("WFDMIndexDate-" + versionNumber)) {
         metaArray.remove(i);
-        break;
       }
 
       // By default the API inherits the parent folders meta value, 


### PR DESCRIPTION
These break statements are potentially causing fields to always show as null, leading to the default fields always overwriting to null.